### PR TITLE
feat: parse query parameters for click IDs of social platforms and affiliate references

### DIFF
--- a/internal/web/db/event.go
+++ b/internal/web/db/event.go
@@ -127,7 +127,7 @@ func parseQueryAdvertisements(q url.Values) url.Values {
 	}
 
 	// if there are utm parameters, do not overwrite them
-	if q.Get("utm_medium") != "" || q.Get("utm_source") != "" || q.Get("utm_campaign") != "" {
+	if q.Get("utm_medium") != "" || q.Get("utm_source") != "" {
 		return q
 	}
 
@@ -159,7 +159,7 @@ func parseQueryAdvertisements(q url.Values) url.Values {
 
 	if q.Get("ScCid") != "" || q.Get("sccid") != "" || q.Get("SCCID") != "" {
 		q.Set("utm_medium", "cpc")
-		q.Set("utm_source", "snaps")
+		q.Set("utm_source", "snapchat")
 	}
 
 	// Put bing and google as last, in case someone shares the gclid or msclkid on other socials, that takes precedence


### PR DESCRIPTION
Parse and correctly populate the utm_medium and utm_source parameters using query parameters for various platforms and affiliates.

Supports the following affiliates and platforms by their respective query parameters:

- **Affiliates**: ref, affiliate
- **Social platforms**: Facebook, Twitter, Reddit, LinkedIn, TikTok, Snapchat, Bing, Google _(by their respective Click IDs)_
