### PR TITLE
🩹 — Fix domain settings link in site-switcher

### DIFF
--- a/assets/js/dashboard/site-switcher.js
+++ b/assets/js/dashboard/site-switcher.js
@@ -167,7 +167,7 @@ export default class SiteSwitcher extends React.Component {
             <a
               href={`/${encodeURIComponent(
                 this.props.site.domain
-              )}/settings/general`}
+              )}/settings`}
               className="group flex items-center px-4 py-2 md:text-sm leading-5 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-900 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-900 focus:text-gray-900 dark:focus:text-gray-100"
               role="menuitem"
             >


### PR DESCRIPTION
Currently, when clicking on `Site Settings`, you end up on `/domain/settings/general`, which is a 404 page.

Correct link is `/domain/settings`. This PR should fix that (untested, but simple fix).