### PR TITLE
add Fly.io client IP header

### DIFF
--- a/internal/web/db/event_request.go
+++ b/internal/web/db/event_request.go
@@ -190,7 +190,7 @@ func (rq *Request) parseUri(m map[string]any) error {
 
 var remoteIPHeaders = []string{
 	"x-vince-ip", "cf-connecting-ip", "b-forwarded-for",
-	"X-Real-IP", "X-Forwarded-For", "X-Client-IP",
+	"X-Real-IP", "X-Forwarded-For", "X-Client-IP", "Fly-Client-IP",
 }
 
 func remoteIP(r *http.Request) string {


### PR DESCRIPTION
Add proxy header to get the client IP when running vince on fly.io

Docs: https://fly.io/docs/networking/request-headers/#fly-client-ip