### PR TITLE
`referrer.name` is already http(s)://

### DIFF
--- a/assets/js/dashboard/stats/sources/referrer-list.js
+++ b/assets/js/dashboard/stats/sources/referrer-list.js
@@ -28,7 +28,7 @@ export default function Referrers({ source }) {
 
   function externalLinkDest(referrer) {
     if (referrer.name === 'Direct / None') { return null }
-    return `https://${referrer.name}`
+    return referrer.name
   }
 
   function getFilterFor(referrer) {


### PR DESCRIPTION
The FE renders referrers links incorrectly - with a double http... prefix

for https://demo.vinceanalytics.com/vinceanalytics.com?filters=((is,source,(demo.vinceanalytics.com)))

the referrer link is set as `https://https://demo.vinceanalytics.com`