### PR TITLE
add new translation and batch package

### DIFF
--- a/gen/go/vince/v1/config.pb.go
+++ b/gen/go/vince/v1/config.pb.go
@@ -22,14 +22,14 @@ const (
 
 type Site struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            uint64                 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
 	Domain        string                 `protobuf:"bytes,2,opt,name=domain,proto3" json:"domain,omitempty"`
+	Public        bool                   `protobuf:"varint,3,opt,name=public,proto3" json:"public,omitempty"`
 	Shares        []*Share               `protobuf:"bytes,4,rep,name=shares,proto3" json:"shares,omitempty"`
+	Locked        bool                   `protobuf:"varint,5,opt,name=locked,proto3" json:"locked,omitempty"`
 	Goals         []*Goal                `protobuf:"bytes,6,rep,name=goals,proto3" json:"goals,omitempty"`
 	unknownFields protoimpl.UnknownFields
-	Id            uint64 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
 	sizeCache     protoimpl.SizeCache
-	Public        bool `protobuf:"varint,3,opt,name=public,proto3" json:"public,omitempty"`
-	Locked        bool `protobuf:"varint,5,opt,name=locked,proto3" json:"locked,omitempty"`
 }
 
 func (x *Site) Reset() {
@@ -218,9 +218,9 @@ func (x *Share) GetPassword() []byte {
 
 type System struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
+	Expiry        uint64                 `protobuf:"varint,1,opt,name=expiry,proto3" json:"expiry,omitempty"`
 	Email         string                 `protobuf:"bytes,2,opt,name=email,proto3" json:"email,omitempty"`
 	unknownFields protoimpl.UnknownFields
-	Expiry        uint64 `protobuf:"varint,1,opt,name=expiry,proto3" json:"expiry,omitempty"`
 	sizeCache     protoimpl.SizeCache
 }
 

--- a/gen/go/vince/v1/config.pb.go
+++ b/gen/go/vince/v1/config.pb.go
@@ -22,14 +22,14 @@ const (
 
 type Site struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            uint64                 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
 	Domain        string                 `protobuf:"bytes,2,opt,name=domain,proto3" json:"domain,omitempty"`
-	Public        bool                   `protobuf:"varint,3,opt,name=public,proto3" json:"public,omitempty"`
 	Shares        []*Share               `protobuf:"bytes,4,rep,name=shares,proto3" json:"shares,omitempty"`
-	Locked        bool                   `protobuf:"varint,5,opt,name=locked,proto3" json:"locked,omitempty"`
 	Goals         []*Goal                `protobuf:"bytes,6,rep,name=goals,proto3" json:"goals,omitempty"`
 	unknownFields protoimpl.UnknownFields
+	Id            uint64 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
 	sizeCache     protoimpl.SizeCache
+	Public        bool `protobuf:"varint,3,opt,name=public,proto3" json:"public,omitempty"`
+	Locked        bool `protobuf:"varint,5,opt,name=locked,proto3" json:"locked,omitempty"`
 }
 
 func (x *Site) Reset() {
@@ -218,9 +218,9 @@ func (x *Share) GetPassword() []byte {
 
 type System struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Expiry        uint64                 `protobuf:"varint,1,opt,name=expiry,proto3" json:"expiry,omitempty"`
 	Email         string                 `protobuf:"bytes,2,opt,name=email,proto3" json:"email,omitempty"`
 	unknownFields protoimpl.UnknownFields
+	Expiry        uint64 `protobuf:"varint,1,opt,name=expiry,proto3" json:"expiry,omitempty"`
 	sizeCache     protoimpl.SizeCache
 }
 

--- a/internal/batch/batch.go
+++ b/internal/batch/batch.go
@@ -17,13 +17,13 @@ import (
 )
 
 type Batch struct {
-	keys   [models.MutexFieldSize][][]byte
 	tr     *translate.Transtate
+	data   map[key]*roaring.Bitmap
+	keys   [models.MutexFieldSize][][]byte
 	views  [encoding.Month + 1]uint64
 	domain uint64
 	id     uint64
 	shard  uint64
-	data   map[key]*roaring.Bitmap
 }
 
 func New(tr *translate.Transtate, startID uint64) *Batch {

--- a/internal/batch/batch.go
+++ b/internal/batch/batch.go
@@ -1,0 +1,209 @@
+package batch
+
+import (
+	"bytes"
+	"iter"
+	"time"
+
+	"github.com/gernest/roaring"
+	"github.com/gernest/roaring/shardwidth"
+	v1 "github.com/vinceanalytics/vince/gen/go/vince/v1"
+	"github.com/vinceanalytics/vince/internal/compute"
+	"github.com/vinceanalytics/vince/internal/encoding"
+	"github.com/vinceanalytics/vince/internal/models"
+	"github.com/vinceanalytics/vince/internal/ro2"
+	"github.com/vinceanalytics/vince/internal/translate"
+	"github.com/vinceanalytics/vince/internal/util/xtime"
+)
+
+type Batch struct {
+	keys   [models.MutexFieldSize][][]byte
+	tr     *translate.Transtate
+	views  [encoding.Month + 1]uint64
+	domain uint64
+	id     uint64
+	shard  uint64
+	data   map[key]*roaring.Bitmap
+}
+
+func New(tr *translate.Transtate, startID uint64) *Batch {
+	return &Batch{
+		tr:   tr,
+		data: make(map[key]*roaring.Bitmap),
+		id:   startID,
+	}
+}
+
+type key struct {
+	field      models.Field
+	shard      uint64
+	view       uint64
+	domain     uint64
+	exists     bool
+	resolution encoding.Resolution
+}
+
+func (b *Batch) Reset() {
+	for i := range b.keys {
+		clear(b.keys[i])
+		b.keys[i] = b.keys[i][:0]
+	}
+	clear(b.data)
+}
+
+func (b *Batch) IterKeys() iter.Seq2[models.Field, []byte] {
+	return func(yield func(models.Field, []byte) bool) {
+		for i := range b.keys {
+			f := models.Mutex(i)
+			for j := range b.keys[i] {
+				if !yield(f, b.keys[i][j]) {
+					return
+				}
+			}
+		}
+	}
+}
+
+type Conainer struct {
+	Field      v1.Field
+	Shard      uint64
+	View       uint64
+	Existence  bool
+	Resolution encoding.Resolution
+	Key        uint64
+}
+
+func (b *Batch) IterContainers() iter.Seq2[Conainer, *roaring.Container] {
+	return func(yield func(Conainer, *roaring.Container) bool) {
+		for k, v := range b.data {
+
+			it, _ := v.Containers.Iterator(0)
+			for it.Next() {
+				key, co := it.Value()
+
+				if !yield(Conainer{
+					Field:      k.field,
+					Shard:      k.shard,
+					View:       k.view,
+					Existence:  k.exists,
+					Resolution: k.resolution,
+					Key:        key,
+				}, co) {
+					return
+				}
+			}
+		}
+	}
+}
+
+func (b *Batch) Next(ts time.Time, domain []byte) {
+	b.views[encoding.Minute] = uint64(compute.Minute(ts).UnixMilli())
+	b.views[encoding.Hour] = uint64(compute.Hour(ts).UnixMilli())
+	b.views[encoding.Week] = uint64(compute.Week(ts).UnixMilli())
+	b.views[encoding.Day] = uint64(compute.Date(ts).UnixMilli())
+	b.domain = b.translate(v1.Field_domain, domain)
+	b.id++
+	b.shard = b.id / shardwidth.ShardWidth
+}
+
+func (b *Batch) Add(m *models.Model) {
+	if m.Timestamp == 0 || m.Id == 0 || len(m.Domain) == 0 {
+		// Skip events without timestamp, id or domain
+		return
+	}
+	b.Next(xtime.UnixMilli(m.Timestamp), m.Domain)
+
+	b.Int64(v1.Field_timestamp, m.Timestamp)
+	b.Int64(v1.Field_id, int64(m.Id))
+	b.Bool(v1.Field_bounce, m.Bounce == 1)
+	b.Bool(v1.Field_session, m.Session)
+	b.Bool(v1.Field_view, m.View)
+	b.Int64(v1.Field_duration, m.Duration)
+	b.Mutex(v1.Field_city, uint64(m.City))
+
+	b.String(v1.Field_domain, m.Domain)
+	b.String(v1.Field_browser, m.Browser)
+	b.String(v1.Field_browser_version, m.BrowserVersion)
+	b.String(v1.Field_country, m.Country)
+	b.String(v1.Field_device, m.Device)
+	b.String(v1.Field_entry_page, m.EntryPage)
+	b.String(v1.Field_event, m.Event)
+	b.String(v1.Field_exit_page, m.ExitPage)
+	b.String(v1.Field_host, m.Host)
+	b.String(v1.Field_os, m.Os)
+	b.String(v1.Field_os_version, m.OsVersion)
+	b.String(v1.Field_page, m.Page)
+	b.String(v1.Field_referrer, m.Referrer)
+	b.String(v1.Field_source, m.Source)
+	b.String(v1.Field_utm_campaign, m.UtmCampaign)
+	b.String(v1.Field_utm_content, m.UtmContent)
+	b.String(v1.Field_utm_medium, m.UtmMedium)
+	b.String(v1.Field_utm_source, m.UtmSource)
+	b.String(v1.Field_utm_term, m.UtmTerm)
+	b.String(v1.Field_subdivision1_code, m.Subdivision1Code)
+	b.String(v1.Field_subdivision2_code, m.Subdivision2Code)
+}
+
+func (b *Batch) Int64(f models.Field, value int64) {
+	if value == 0 {
+		return
+	}
+	b.ra(f, false, func(ra *roaring.Bitmap) {
+		ro2.WriteBSI(ra, b.id, value)
+	})
+}
+
+func (b *Batch) Bool(f models.Field, value bool) {
+	b.ra(f, false, func(ra *roaring.Bitmap) {
+		ro2.WriteBool(ra, b.id, value)
+	})
+}
+
+func (b *Batch) String(f models.Field, value []byte) {
+	if len(value) == 0 {
+		return
+	}
+	row := b.translate(f, value)
+	b.Mutex(f, row)
+}
+
+func (b *Batch) Mutex(f models.Field, row uint64) {
+	if row == 0 {
+		return
+	}
+	b.ra(f, false, func(ra *roaring.Bitmap) {
+		ro2.WriteMutex(ra, b.id, row)
+	})
+	b.ra(f, true, func(ra *roaring.Bitmap) {
+		ra.DirectAdd(b.id % shardwidth.ShardWidth)
+	})
+}
+
+func (b *Batch) ra(field models.Field, exists bool, f func(ra *roaring.Bitmap)) {
+	for i := range b.views {
+		k := key{
+			field:      field,
+			shard:      b.shard,
+			view:       b.views[i],
+			domain:     b.domain,
+			resolution: encoding.Resolution(i),
+			exists:     exists,
+		}
+		r := b.data[k]
+		if r == nil {
+			r = roaring.NewBitmap()
+			b.data[k] = r
+		}
+		f(r)
+	}
+
+}
+
+func (b *Batch) translate(f models.Field, data []byte) uint64 {
+	id, ok := b.tr.Get(f, data)
+	if !ok {
+		idx := models.AsMutex(f)
+		b.keys[idx] = append(b.keys[idx], bytes.Clone(data))
+	}
+	return id
+}

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -95,7 +95,3 @@ func ACME(key []byte) []byte {
 	copy(o[2:], key)
 	return o
 }
-
-func num(b []byte, v uint64) []byte {
-	return binary.BigEndian.AppendUint64(b, v)
-}

--- a/internal/encoding/encoding_test.go
+++ b/internal/encoding/encoding_test.go
@@ -11,69 +11,69 @@ import (
 
 func TestPrefix(t *testing.T) {
 	type T struct {
+		key    func() []byte
 		name   string
 		prefix []byte
-		key    func() []byte
 	}
 
 	samples := []T{
 		{
-			"bitmap data",
-			keys.DataPrefix,
-			func() []byte {
+			name:   "bitmap data",
+			prefix: keys.DataPrefix,
+			key: func() []byte {
 				var k Key
 				k.WriteData(Global, v1.Field_domain, 0, 0, 0)
 				return k.Bytes()
 			},
 		},
 		{
-			"bitmap existence",
-			keys.DataExistsPrefix,
-			func() []byte {
+			name:   "bitmap existence",
+			prefix: keys.DataExistsPrefix,
+			key: func() []byte {
 				var k Key
 				k.WriteExistence(Global, v1.Field_domain, 0, 0, 0)
 				return k.Bytes()
 			},
 		},
 		{
-			"site",
-			keys.SitePrefix,
-			func() []byte {
+			name:   "site",
+			prefix: keys.SitePrefix,
+			key: func() []byte {
 				return Site([]byte("test"))
 			},
 		},
 		{
-			"api key name",
-			keys.APIKeyNamePrefix,
-			func() []byte {
+			name:   "api key name",
+			prefix: keys.APIKeyNamePrefix,
+			key: func() []byte {
 				return APIKeyName([]byte("test"))
 			},
 		},
 		{
-			"api key hash",
-			keys.APIKeyHashPrefix,
-			func() []byte {
+			name:   "api key hash",
+			prefix: keys.APIKeyHashPrefix,
+			key: func() []byte {
 				return APIKeyHash([]byte("test"))
 			},
 		},
 		{
-			"acme",
-			keys.AcmePrefix,
-			func() []byte {
+			name:   "acme",
+			prefix: keys.AcmePrefix,
+			key: func() []byte {
 				return ACME([]byte("test"))
 			},
 		},
 		{
-			"translate Key",
-			keys.TranslateKeyPrefix,
-			func() []byte {
+			name:   "translate Key",
+			prefix: keys.TranslateKeyPrefix,
+			key: func() []byte {
 				return TranslateKey(v1.Field_domain, []byte("test"))
 			},
 		},
 		{
-			"translate id",
-			keys.TranslateIDPrefix,
-			func() []byte {
+			name:   "translate id",
+			prefix: keys.TranslateIDPrefix,
+			key: func() []byte {
 				return TranslateID(v1.Field_domain, 0)
 			},
 		},

--- a/internal/models/event_model.go
+++ b/internal/models/event_model.go
@@ -39,10 +39,10 @@ type Model struct {
 }
 
 type Cached struct {
-	Start     int64
 	EntryPage []byte
 	Host      []byte
 	ExitPage  []byte
+	Start     int64
 	Timestamp int64
 	Bounce    int8
 }

--- a/internal/models/fields.go
+++ b/internal/models/fields.go
@@ -4,22 +4,13 @@ import v1 "github.com/vinceanalytics/vince/gen/go/vince/v1"
 
 const (
 	MutexFieldSize       = v1.Field_session + 1
-	TranslatedFieldsSize = v1.Field_subdivision2_code + 1
-	SearchFieldSize      = v1.Field_city + 1
+	TranslatedFieldsSize = v1.Field_subdivision2_code
 	BSIFieldsSize        = v1.Field_duration - v1.Field_timestamp + 1
 	AllFields            = v1.Field_duration + 1
 )
 
 func AsMutex(f Field) byte {
-	return byte(f)
-}
-
-func AsBSI(f Field) byte {
-	return byte(f - v1.Field_timestamp)
-}
-
-func BSI(i int) Field {
-	return Field(i) + v1.Field_timestamp
+	return byte(f - v1.Field_domain)
 }
 
 func Mutex(i int) Field {

--- a/internal/models/fields_test.go
+++ b/internal/models/fields_test.go
@@ -10,7 +10,5 @@ func TestTranslate(t *testing.T) {
 	for n := range int(MutexFieldSize) {
 		require.Equal(t, n, int(AsMutex(Mutex(n))))
 	}
-	for n := range int(BSIFieldsSize) {
-		require.Equal(t, n, int(AsBSI(BSI(n))))
-	}
+
 }

--- a/internal/ops/system_operations.go
+++ b/internal/ops/system_operations.go
@@ -24,15 +24,15 @@ import (
 )
 
 type Ops struct {
-	sites struct {
-		domains map[string]*v1.Site
-		sync.RWMutex
-	}
 	tr    translation.Translator
 	db    *pebble.DB
 	admin struct {
 		name     string
 		password []byte
+	}
+	sites struct {
+		domains map[string]*v1.Site
+		sync.RWMutex
 	}
 }
 

--- a/internal/ops/system_operations.go
+++ b/internal/ops/system_operations.go
@@ -25,14 +25,8 @@ import (
 
 type Ops struct {
 	sites struct {
+		domains map[string]*v1.Site
 		sync.RWMutex
-		domains map[ // We expect a reasonable number of sites to be managed by a single instance
-		// we keep this in memory because we ask for sites a lot when a user access
-		// dashboard. It will bring a lot of stress on pebble for those excessive
-		// lookups.
-		//
-		// Values must never be modified. Use cloneProto for safe copies.
-		string]*v1.Site
 	}
 	tr    translation.Translator
 	db    *pebble.DB

--- a/internal/ops/system_operations.go
+++ b/internal/ops/system_operations.go
@@ -24,21 +24,21 @@ import (
 )
 
 type Ops struct {
-	db    *pebble.DB
-	tr    translation.Translator
-	admin struct {
-		name     string
-		password []byte
-	}
 	sites struct {
 		sync.RWMutex
-		// We expect a reasonable number of sites to be managed by a single instance
+		domains map[ // We expect a reasonable number of sites to be managed by a single instance
 		// we keep this in memory because we ask for sites a lot when a user access
 		// dashboard. It will bring a lot of stress on pebble for those excessive
 		// lookups.
 		//
 		// Values must never be modified. Use cloneProto for safe copies.
-		domains map[string]*v1.Site
+		string]*v1.Site
+	}
+	tr    translation.Translator
+	db    *pebble.DB
+	admin struct {
+		name     string
+		password []byte
 	}
 }
 

--- a/internal/shards/shard.go
+++ b/internal/shards/shard.go
@@ -47,9 +47,9 @@ type DB struct {
 	ops    *pebble.DB
 	base   string
 	shards struct {
-		sync.RWMutex
 		data [1 << 10]*Shard
 		max  uint64
+		sync.RWMutex
 	}
 }
 
@@ -155,8 +155,8 @@ func (db *DB) Close() error {
 }
 
 type Shard struct {
-	ID uint64
 	DB *pebble.DB
+	ID uint64
 }
 
 func NewShard(base string, shard uint64) *Shard {

--- a/internal/timeseries/timeseries_batch.go
+++ b/internal/timeseries/timeseries_batch.go
@@ -72,10 +72,6 @@ func (b *batch) setTs(timestamp int64) {
 	b.views[encoding.Day] = uint64(compute.Date(ts).UnixMilli())
 }
 
-func (b *batch) setDomain(m *models.Model) {
-
-}
-
 // saves only current timestamp.
 func (b *batch) save() error {
 	if b.events == 0 {

--- a/internal/timeseries/timeseries_filters.go
+++ b/internal/timeseries/timeseries_filters.go
@@ -45,13 +45,13 @@ func (o Or) Apply(cu *cursor.Cursor, re encoding.Resolution, shard, view uint64)
 }
 
 type Yes struct {
-	Field  models.Field
 	Values []uint64
+	Field  models.Field
 }
 
 type No struct {
-	Field  models.Field
 	Values []uint64
+	Field  models.Field
 }
 
 // Apply searches for columns matching conditions in f for ra bitmap. ra must be

--- a/internal/translate/translate.go
+++ b/internal/translate/translate.go
@@ -26,8 +26,8 @@ func (t *Transtate) Get(field models.Field, value []byte) (uint64, bool) {
 var seed = maphash.MakeSeed()
 
 type mapping struct {
-	mu sync.RWMutex
 	ma map[uint64]uint64
+	mu sync.RWMutex
 }
 
 func (m *mapping) Get(value []byte) (id uint64, found bool) {

--- a/internal/translate/translate.go
+++ b/internal/translate/translate.go
@@ -1,0 +1,47 @@
+package translate
+
+import (
+	"hash/maphash"
+	"sync"
+
+	"github.com/vinceanalytics/vince/internal/models"
+)
+
+type Transtate struct {
+	mapping [models.TranslatedFieldsSize]*mapping
+}
+
+func New() *Transtate {
+	t := new(Transtate)
+	for i := range t.mapping {
+		t.mapping[i] = &mapping{ma: make(map[uint64]uint64)}
+	}
+	return t
+}
+
+func (t *Transtate) Get(field models.Field, value []byte) (uint64, bool) {
+	return t.mapping[models.AsMutex(field)].Get(value)
+}
+
+var seed = maphash.MakeSeed()
+
+type mapping struct {
+	mu sync.RWMutex
+	ma map[uint64]uint64
+}
+
+func (m *mapping) Get(value []byte) (id uint64, found bool) {
+	ha := maphash.Bytes(seed, value)
+	m.mu.RLock()
+	id, found = m.ma[ha]
+	m.mu.RUnlock()
+	if found {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	id = uint64(len(m.ma) + 1)
+	m.ma[ha] = id
+	return
+}

--- a/internal/translate/translate_test.go
+++ b/internal/translate/translate_test.go
@@ -29,5 +29,6 @@ func TestTranslate(t *testing.T) {
 		ts := New()
 		require.Equal(t, uint8(0), models.AsMutex(v1.Field_domain))
 		require.Equal(t, uint8(len(ts.mapping)-1), models.AsMutex(v1.Field_subdivision2_code))
+		_ = ts
 	})
 }

--- a/internal/translate/translate_test.go
+++ b/internal/translate/translate_test.go
@@ -1,0 +1,33 @@
+package translate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "github.com/vinceanalytics/vince/gen/go/vince/v1"
+	"github.com/vinceanalytics/vince/internal/models"
+)
+
+func TestTranslate(t *testing.T) {
+
+	t.Run("panics on non mutex fields", func(t *testing.T) {
+		ts := New()
+		for f := v1.Field_view; f <= v1.Field_duration; f++ {
+			require.Panics(t, func() { ts.Get(f, nil) })
+		}
+	})
+	t.Run("works for mutex fields", func(t *testing.T) {
+		ts := New()
+		for f := v1.Field_domain; f <= v1.Field_subdivision2_code; f++ {
+			id, ok := ts.Get(f, []byte("hello"))
+			require.Equal(t, uint64(1), id)
+			require.False(t, ok)
+		}
+	})
+
+	t.Run("safe bounds", func(t *testing.T) {
+		ts := New()
+		require.Equal(t, uint8(0), models.AsMutex(v1.Field_domain))
+		require.Equal(t, uint8(len(ts.mapping)-1), models.AsMutex(v1.Field_subdivision2_code))
+	})
+}

--- a/internal/ua2/gen/main.go
+++ b/internal/ua2/gen/main.go
@@ -256,17 +256,17 @@ func makeClient(root string) {
 }
 
 type ClientReg struct {
+	Engine  *Engine `yaml:"engine" json:"engine"`
 	Regex   string  `yaml:"regex" json:"regex"`
 	Name    string  `yaml:"name" json:"name"`
 	Version string  `yaml:"version" json:"version"`
 	Url     string  `yaml:"url" json:"url"`
 	Type    string  `yaml:"type" json:"type"`
-	Engine  *Engine `yaml:"engine" json:"engine"`
 }
 
 type Engine struct {
-	Default  string            `yaml:"default" json:"default"`
 	Versions map[string]string `yaml:"versions" json:"versions"`
+	Default  string            `yaml:"default" json:"default"`
 }
 
 func genBrowserEngine(b *bytes.Buffer, root string) {

--- a/internal/util/lru/lru.go
+++ b/internal/util/lru/lru.go
@@ -21,11 +21,9 @@ import "container/list"
 
 // Cache is an LRU cache. It is not safe for concurrent access.
 type Cache[Key comparable, Value any] struct {
-	// MaxEntries is the maximum number of cache entries before
-	// an item is evicted. Zero means no limit.
-	MaxEntries int
 	ll         *list.List
 	cache      map[Key]*list.Element
+	MaxEntries int
 }
 
 type entry[Key, Value any] struct {

--- a/internal/util/oracle/globals.go
+++ b/internal/util/oracle/globals.go
@@ -13,8 +13,9 @@ var (
 	DataPath string
 
 	Acme struct {
-		Enabled       bool
-		Email, Domain string
+		Email   string
+		Domain  string
+		Enabled bool
 	}
 
 	Endpoint string


### PR DESCRIPTION
Take advantage of swiss maps for `go1.24` to keep translation data in memory. The new batch package is storage agnostic 