### PR TITLE
Fix: Password-protected shared links were accessible without a password

### DIFF
--- a/internal/web/site.go
+++ b/internal/web/site.go
@@ -234,7 +234,7 @@ func RequireSiteAccess(h plug.Handler) plug.Handler {
 				// verify shared link
 				name := "shared-link-" + auth
 				expires := db.LoadSharedLinkSession(r, name)
-				if expires.After(xtime.Now()) {
+				if expires.Before(xtime.Now()) {
 					dest := fmt.Sprintf("/v1/share/%s/authenticate/%s",
 						url.PathEscape(site.Domain), auth)
 					http.Redirect(w, r, dest, http.StatusFound)


### PR DESCRIPTION
### Overview
This pull request fixes a critical issue where password-protected shared links could be accessed without being prompted for a password.

### What Was Happening
Even when a shared link was configured with a password, users were never asked to enter it. As a result, anyone with the link could access the content — bypassing the intended security.

### What’s Fixed
- The system now correctly detects when a shared link is password-protected.
- Users are required to enter the correct password before access is granted.

### Testing
- Created a shared link with a password.
- Verified that the password prompt appears.
- Confirmed that access is only granted after entering the correct password.

### Notes
This restores the intended behavior for password-protected links. Let me know if you'd like additional test coverage or any refinements.
