### PR TITLE
Fix crash of the stats page with goals

### DIFF
--- a/assets/js/dashboard/stats/reports/list.js
+++ b/assets/js/dashboard/stats/reports/list.js
@@ -69,6 +69,7 @@ function ExternalLink({ item, externalLinkDest }) {
  *    `renderLabel`, and `renderValue` fields. Optionally, a Metric object can contain
  *    the keys `meta.plot` and `meta.hiddenOnMobile` to represent additional behavior
  *    for this metric in the ListReport.
+ * @param {number} colMinWidth - Minimum width of each column in pixels.
  * @param {Function} getFilterFor - A function that takes a list item and returns [prefix, filter, labels]
  *    that should be applied when the list item is clicked. All existing filters matching prefix
  *    are removed. If a list item is not supposed to be clickable, this function should
@@ -238,7 +239,7 @@ export default function ListReport({ keyLabel, metrics, colMinWidth = COL_MIN_WI
               {maybeRenderIconFor(listItem)}
 
               <span className="w-full md:truncate">
-                {trimURL(listItem.name, colMinWidth)}
+                {trimURL(listItem.name || listItem.event, colMinWidth)}
               </span>
             </FilterLink>
             <ExternalLink item={listItem} externalLinkDest={externalLinkDest} />

--- a/assets/js/dashboard/util/url.js
+++ b/assets/js/dashboard/util/url.js
@@ -24,6 +24,10 @@ export function isValidHttpUrl(string) {
 
 
 export function trimURL(url, maxLength) {
+  if (url === null || url === undefined) {
+      console.warn("url to trim is null or undefined")
+      return url;
+  }
   if (url.length <= maxLength) {
     return url;
   }


### PR DESCRIPTION
See issue #77 for details but in a nutshell:
- create a goal "toto"
- trigger the event from your web page (note that the documentation mixes plausible-event-name and vince-event-name but only the plausible one works)
- go to the stats page => page blows up with an exception e.length on undefined e.

That's because the event doesn't have a .name, only .event. I supported both in list.js and shielded trimUrl that was starting with url.length...

I didn't find a previous PR with updates to the Javascript and since the JS artefacts seem to be manually generated, I included them in a separate commit. Feel free to exclude it, cherry pick the rest and regenerate it yourself, or ask me to remove it if necessary. I know that I didn't (intentionally) include any malicious code in there but I wouldn't trust a stranger to include minified JS code like that in my projects. Maybe adding a Github action would be useful ?

I also removed some deprecated .substr() in the same file.